### PR TITLE
feat: improve imports

### DIFF
--- a/src/yardgoat/__init__.py
+++ b/src/yardgoat/__init__.py
@@ -1,4 +1,5 @@
 from . import bundle
+from . import types
 from .version import __version__
 
 del version

--- a/src/yardgoat/bundle/__init__.py
+++ b/src/yardgoat/bundle/__init__.py
@@ -1,3 +1,6 @@
-from . import bundler
+from .bundler import *
+from .config import BundleConfig
 from . import config
 from . import exceptions
+
+del bundler

--- a/src/yardgoat/bundle/bundler.py
+++ b/src/yardgoat/bundle/bundler.py
@@ -77,4 +77,4 @@ def create_bundle(path: PathLike) -> BundleInfo:
         return BundleInfo(config=config, tarfile=tarfile)
 
 
-__all__ = ["BundleInfo", "create_bundle"]
+__all__ = ["BUNDLE_CONFIG_FILENAME", "BundleInfo", "create_bundle"]


### PR DESCRIPTION
Improve imports in the bundle package by making it easier to access globals, classes, and functions
from the bundle.bundler module by importing them directly into the bundle namespace. Additionally,
import the `BundleConfig` class from bundle.config directly into the bundle namespace. Lastly,
import the types module into the yardgoat namespace automatically now.

BREAKING CHANGE: yardgoat.bundle.bundler is no longer valid unless imported directly.