### PR TITLE
feat(engine): implement docker yardgoat runtime

### DIFF
--- a/src/yardgoat/__init__.py
+++ b/src/yardgoat/__init__.py
@@ -1,4 +1,5 @@
 from . import bundle
+from . import engine
 from . import storage
 from . import types
 from .version import __version__

--- a/src/yardgoat/bundle/bundler.py
+++ b/src/yardgoat/bundle/bundler.py
@@ -91,4 +91,38 @@ def create_bundle(path: PathLike) -> BundleInfo:
         return BundleInfo(config=config, tarfile=tarfile)
 
 
-__all__ = ["BUNDLE_CONFIG_FILENAME", "BundleInfo", "create_bundle"]
+def extract(bundle: BundleInfo, destination: Optional[PathLike] = None):
+    """Extract the Bundle to the specified directory.
+
+    Args:
+        bundle (BundleInfo): The Bundle to extract.
+        destination (PathLike, optional): The location to place the contents of the
+            Bundle. Defaults to the current working directory.
+    """
+
+    with TarFile(bundle.tarfile, mode="r") as tar:
+        tar.extractall(destination)
+
+
+def extract_volume_files(bundle: BundleInfo, destination: Optional[PathLike] = None):
+    """Extract all files listed as a volume of the Bundle to the specified directory.
+
+    Args:
+        bundle (BundleInfo): The Bundle from which to extract the volume files.
+        destination (PathLike, optional): The location to place the contents of the
+            Bundle. Defaults to the current working directory.
+    """
+
+    with TarFile(bundle.tarfile, mode="r") as tar:
+        members = tar.getmembers()
+        members = [member for member in members if member.name in bundle.config.volumes]
+        tar.extractall(path=destination, members=members)
+
+
+__all__ = [
+    "BUNDLE_CONFIG_FILENAME",
+    "BundleInfo",
+    "create_bundle",
+    "extract",
+    "extract_volume_files",
+]

--- a/src/yardgoat/engine/__init__.py
+++ b/src/yardgoat/engine/__init__.py
@@ -1,0 +1,5 @@
+from . import docker
+from .engine import *
+from . import types
+
+del engine

--- a/src/yardgoat/engine/docker.py
+++ b/src/yardgoat/engine/docker.py
@@ -1,0 +1,84 @@
+import pathlib
+import platform
+from tempfile import TemporaryDirectory
+from typing import Optional
+
+import docker
+
+from .exceptions import MissingVolumeFile
+from .types import Artifact, Engine
+from ..bundle import BundleInfo, extract, extract_volume_files
+
+YARDGOAT_DOCKER_PREFIX = "yardgoat.runner"
+# We need to force TemporaryDirectory to be in /tmp for macOS.
+_TMPDIR = pathlib.Path("/tmp") if platform.system() == "Darwin" else None
+
+
+class DockerEngine(Engine):
+    """Docker-based :class:`Engine` runtime implementation.
+
+    This `Engine` implementation interfaces with the
+    [Docker Engine](https://docs.docker.com/engine/), enabling yardgoat to execute
+    Docker-based batch jobs.
+
+    Args:
+        client (docker.DockerClient): Docker client instance. Defaults to `None`, causing
+            this instance to create its own client.
+    
+    Attributes:
+        client (docker.DockerClient): The Docker client instance this instance is using.
+    """
+
+    def __init__(self, client: Optional[docker.DockerClient] = None):
+        if client is None:
+            client = docker.client.from_env()
+        self.client = client
+
+    def build(self, bundle: BundleInfo) -> Artifact:
+        with TemporaryDirectory() as tempdir:
+            extract(bundle, destination=tempdir)
+
+            image, _ = self.client.images.build(
+                path=tempdir,
+                tag=f"{YARDGOAT_DOCKER_PREFIX}/{bundle.config.name}",
+                labels={"goat:sha256": bundle.tarfile.stem},
+                rm=True,
+            )
+
+            return Artifact(
+                name=image.id,
+                bundle=bundle,
+                metadata={
+                    "tags": image.tags,
+                    "labels": image.labels,
+                    "short_id": image.short_id,
+                },
+            )
+
+    def execute(self, artifact: Artifact):
+        with TemporaryDirectory(dir=_TMPDIR) as tempdir:
+            tempdir = pathlib.Path(tempdir)
+            extract_volume_files(artifact.bundle, destination=tempdir)
+            volumes_absolute_paths = {}
+            for k in artifact.bundle.config.volumes:
+                fp = pathlib.PurePath(k)
+                absolute = tempdir.joinpath(fp)
+                if absolute.exists():
+                    volumes_absolute_paths[absolute] = artifact.bundle.config.volumes[k]
+                elif len(fp.parts) == 1:  # Create a Docker volume.
+                    self.client.volumes.create(name=fp.name, driver="local")
+                    volumes_absolute_paths[fp.name] = artifact.bundle.config.volumes[k]
+                else:
+                    raise MissingVolumeFile(
+                        f"file '{fp}' does not exist in the Bundle file"
+                    )
+
+            return self.client.containers.run(
+                artifact.name,
+                command=artifact.bundle.config.cmd,
+                remove=True,
+                entrypoint=artifact.bundle.config.entrypoint,
+                volumes=volumes_absolute_paths,
+                stdout=True,
+                stderr=True,
+            )

--- a/src/yardgoat/engine/docker_test.py
+++ b/src/yardgoat/engine/docker_test.py
@@ -1,0 +1,162 @@
+import os
+from pathlib import Path
+import random
+from tempfile import TemporaryDirectory
+
+import docker
+import pytest
+
+from .docker import DockerEngine, YARDGOAT_DOCKER_PREFIX
+from ..bundle import BundleInfo, create_bundle
+
+
+@pytest.fixture(scope="module")
+def docker_client():
+    return docker.client.from_env()
+
+
+@pytest.fixture(scope="function")
+def example_bundle():
+    with TemporaryDirectory() as tempdir:
+        with TemporaryDirectory(dir=tempdir) as projectdir:
+            projectdir = Path(projectdir)
+            with projectdir.joinpath("main.sh").open("w") as f:
+                f.write("echo 'Hello World!'")
+            with projectdir.joinpath("Dockerfile").open("w") as f:
+                f.write(
+                    """FROM alpine:latest
+COPY main.sh /opt/bin/
+
+CMD ["/bin/sh", "/opt/bin/main.sh"]
+"""
+                )
+            with projectdir.joinpath("yardgoat.toml").open("w") as f:
+                f.write(f"""name = "{projectdir.name}"\n""")
+
+            yield create_bundle(projectdir)
+
+
+@pytest.fixture(scope="function")
+def example_bundle_with_mount():
+    with TemporaryDirectory() as tempdir:
+        with TemporaryDirectory(dir=tempdir) as projectdir:
+            projectdir = Path(projectdir)
+            with projectdir.joinpath("data.txt").open("w") as f:
+                f.write("Hello World!\n")
+            with projectdir.joinpath("main.sh").open("w") as f:
+                f.write("cat /data.txt")
+            with projectdir.joinpath("Dockerfile").open("w") as f:
+                f.write(
+                    """FROM alpine:latest
+COPY main.sh /opt/bin/
+
+CMD ["/bin/sh", "/opt/bin/main.sh"]
+"""
+                )
+            with projectdir.joinpath("yardgoat.toml").open("w") as f:
+                f.write(
+                    f"""
+name = "{projectdir.name}"
+
+[volumes]
+"data.txt" = "/data.txt"
+"""
+                )
+
+            yield create_bundle(projectdir)
+
+
+@pytest.fixture(scope="function")
+def example_bundle_with_docker_volume():
+    with TemporaryDirectory() as tempdir:
+        with TemporaryDirectory(dir=tempdir) as projectdir:
+            projectdir = Path(projectdir)
+            with projectdir.joinpath("main.sh").open("w") as f:
+                f.write("touch /data/output.txt\n")
+                f.write("echo 'Hello World!' > '/data/output.txt'\n")
+                f.write("cat /data/output.txt")
+            with projectdir.joinpath("Dockerfile").open("w") as f:
+                f.write(
+                    """FROM alpine:latest
+COPY main.sh /opt/bin/
+
+CMD ["/bin/sh", "/opt/bin/main.sh"]
+"""
+                )
+            with projectdir.joinpath("yardgoat.toml").open("w") as f:
+                f.write(
+                    f"""
+name = "{projectdir.name}"
+
+[volumes]
+{projectdir.name} = "/data/"
+"""
+                )
+
+            yield create_bundle(projectdir)
+
+
+def test_DockerEngine_build(docker_client, example_bundle):
+    engine = DockerEngine(docker_client)
+
+    artifact = engine.build(example_bundle)
+
+    try:
+        images = docker_client.images.list(
+            f"{YARDGOAT_DOCKER_PREFIX}/{example_bundle.config.name}"
+        )
+        assert len(images) == 1
+
+        image = images[0]
+        assert image.id == artifact.name
+        assert artifact.metadata["tags"] == image.tags
+        assert artifact.metadata["labels"] == image.labels
+        assert artifact.metadata["short_id"] == image.short_id
+        assert artifact.bundle == example_bundle
+    finally:
+        docker_client.images.remove(artifact.name)
+
+
+def test_DockerEngine_execute(docker_client, example_bundle):
+    engine = DockerEngine(docker_client)
+
+    artifact = engine.build(example_bundle)
+
+    try:
+        out = engine.execute(artifact)
+        assert out and out.decode("utf-8") == "Hello World!\n"
+    finally:
+        docker_client.images.remove(artifact.name)
+
+
+def test_DockerEngine_execute_mount(docker_client, example_bundle_with_mount):
+    engine = DockerEngine(docker_client)
+
+    artifact = engine.build(example_bundle_with_mount)
+
+    try:
+        out = engine.execute(artifact)
+        assert out and out.decode("utf-8") == "Hello World!\n"
+    finally:
+        docker_client.images.remove(artifact.name)
+
+
+def test_DockerEngine_execute_docker_volume(
+    docker_client, example_bundle_with_docker_volume
+):
+    print(example_bundle_with_docker_volume)
+    engine = DockerEngine(docker_client)
+
+    artifact = engine.build(example_bundle_with_docker_volume)
+
+    try:
+        out = engine.execute(artifact)
+        assert out and out.decode("utf-8") == "Hello World!\n"
+
+        volumes = docker_client.volumes.list()
+        assert any(v.name == artifact.bundle.config.name for v in volumes)
+    finally:
+        for v in docker_client.volumes.list():
+            if v.name == artifact.bundle.config.name:
+                v.remove()
+        docker_client.images.remove(artifact.name)

--- a/src/yardgoat/engine/engine.py
+++ b/src/yardgoat/engine/engine.py
@@ -1,0 +1,40 @@
+from enum import Enum
+from typing import Union
+
+from .docker import DockerEngine
+from .types import Engine
+
+
+class Runtime(Enum):
+    """Enumeration of supported execution runtime environments."""
+
+    DOCKER = "docker"  #: Docker Engine runtime.
+
+    @classmethod
+    def from_str(cls, name: str) -> "Engine":
+        lower = name.lower()
+        if lower == cls.DOCKER.value:
+            return cls.DOCKER
+        else:
+            raise ValueError(f"unknown runtime type '{name}'")
+
+
+def new(runtime: Union[Runtime, str]) -> Engine:
+    """Create a new :class:`Engine` with the specified runtime.
+
+    Args:
+        runtime (Union[Runtime, str]): The name of the execution runtime.
+
+    Returns:
+        Engine: An `Engine` instance for the given runtime.
+    """
+    if isinstance(runtime, str):
+        runtime = Runtime.from_str(runtime)
+
+    if runtime == Runtime.DOCKER:
+        return DockerEngine()
+    else:
+        ValueError(f"unknown engine runtime'{runtime}'")
+
+
+__all__ = ["new", "Runtime"]

--- a/src/yardgoat/engine/exceptions.py
+++ b/src/yardgoat/engine/exceptions.py
@@ -1,0 +1,4 @@
+class MissingVolumeFile(FileNotFoundError):
+    """Raised when a host file or directory to be mounted could not be found."""
+
+    pass

--- a/src/yardgoat/engine/types.py
+++ b/src/yardgoat/engine/types.py
@@ -1,0 +1,64 @@
+from typing_extensions import Protocol
+
+import attr
+
+from ..bundle import BundleConfig, BundleInfo
+
+
+@attr.s(frozen=True, slots=True)
+class Artifact:
+    """Represents an assembled Bundle for a given Engine runtime.
+    
+    Note that the original Bundle is included as a reference. This enables
+    :class:`Engine` runtimes to 1) reference the configuration for execution; and 2)
+    access any included files at runtime (e.g., for docker volumes).
+
+    Attributes:
+        name (str): The unique identifier of the artifact.
+        bundle (BundleInfo): The Bundle from which this `Artifact` was assembled.
+        metadata (dict): Any associated metadata about the artifcat.
+    """
+
+    name: str = attr.ib()
+    bundle: BundleInfo = attr.ib()
+    metadata: dict = attr.ib(factory=dict)
+
+
+class Engine(Protocol):
+    """Protocol for building and executing Bundle files.
+
+    This protocol defines a common interface for Bundle building and execution, enabling
+    technologies, such as Docker, to act as an execution runtime for Yardgoat. `Engine`
+    implementations are responsible for two key steps in the Yardgoat execution
+    lifecycle. First, they are responsible for converting a Yardgoat Bundle file into a
+    format that the runtime can handle, which Yardgoat refers to as an :class:`Artifact`
+    (e.g., a Docker image). Note that an `Artifact` is a superset of a Bundle, and
+    includes a reference to the Bundle from which it was built. Second, instances must be
+    able to execute the `Artifact` as configured by the associated :class:`BundleConfig`
+    object. For example, if a user is running a Bundle using Docker, the Docker `Engine`
+    must run the `Artifact` generated for that Bundle with the specified entrypoint,
+    command, and also mount any volumes listed in the configuration.
+    """
+
+    def build(self, bundle: BundleInfo) -> Artifact:
+        """Build the given Bundle for this Engine runtime environment.
+
+        Args:
+            bundle (BundleInfo): The Bundle to build.
+
+
+        Returns:
+            Artifact: The assembled Bundle for this Engine runtime environment.
+        """
+        ...
+
+    def execute(self, artifact: Artifact):
+        """Execute the :class:`Artifact` with the given configuration data.
+
+        Args:
+            artifact (Artifact): The artifact to execute.
+        """
+        ...
+
+
+__all__ = ["Artifact", "Engine"]


### PR DESCRIPTION
Define the core interface for building and executing Bundles: the `Engine` protocol. Additionally, create `DockerEngine`, which implements the `Engine` interface and enables Yardgoat to execute Docker-based batch jobs.